### PR TITLE
Update fluentd.service.j2

### DIFF
--- a/templates/fluentd/fluentd.service.j2
+++ b/templates/fluentd/fluentd.service.j2
@@ -11,7 +11,6 @@ User={{ fluentd_user }}
 Group={{ fluentd_group }}
 
 ExecStart=/usr/local/bin/fluentd -d /run/fluentd/fluentd.pid -c {{ fluentd_conf_path }}/fluent.conf -o {{ fluentd_log_file }}
-ExecStop=/usr/bin/kill -9 $MAINPID
 Restart=always
 
 [Install]


### PR DESCRIPTION
Delete ExecStop as it can trigger an error depending on the OS layout. kill location isn't a reliable thing in the first place (it's living at /bin on Ubuntu), but systemd is able to kill processes without being told how anyway. KillSignal should be used if a SIGKILL signal is really necessary.
